### PR TITLE
Fix build error resolving dependencies by updating third-party to third_party in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 set(EXTRA_COMPONENT_DIRS third_party/golioth-firmware-sdk/port/esp_idf/components)
 list(APPEND EXTRA_COMPONENT_DIRS third_party/arduino)
-list(APPEND EXTRA_COMPONENT_DIRS third-party/esp32-arduino-lib-builder/components/arduino_tinyusb)
+list(APPEND EXTRA_COMPONENT_DIRS third_party/esp32-arduino-lib-builder/components/arduino_tinyusb)
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(golioth_espidf_arduino)


### PR DESCRIPTION
While running `idf.py set-target esp32` you get a "no such file or directory" error due to third-party/esp32-arduino-lib-builder/components/arduino_tinyusb  not existing. Following the instructions in readme that's because it's located in ./third_party not ./third-party. 